### PR TITLE
Fix the Double Logo. 解决首页双logo问题

### DIFF
--- a/public.css
+++ b/public.css
@@ -259,7 +259,7 @@ em {
 #s_form_wrapper {
                margin-top: auto;
 }
-#s_lg_img {
+#s_lg_img_new {
                display: none;
 }
 .s_ipt_wr {


### PR DESCRIPTION
百度采用了新的logo
在第262行id修改为#s_lg_img_new

A little modification for Baidu homepage updated the new logo.
ln 262 new id : #s_lg_img_new